### PR TITLE
Linter fix, documentation, big cleanup

### DIFF
--- a/cosmoz-treenode-button-view.html
+++ b/cosmoz-treenode-button-view.html
@@ -45,21 +45,22 @@ Navigator through object with treelike datastructure.
 	<template>
 		<div class="horizontal layout">
 			<paper-button class="flex" raised on-tap="openDialogTree">
-				<div class="pathToNode">[[ _getButtonLabel(valuePathParts, buttonTextPlaceholder) ]]</div>
+				<div class="pathToNode">[[ _getButtonLabel(nodesOnNodePath, buttonTextPlaceholder) ]]</div>
 			</paper-button>
-			<paper-icon-button icon="clear" on-tap="reset" hidden$="[[ !_enableReset(value, noReset) ]]"></paper-icon-button>
+			<paper-icon-button icon="clear" on-tap="reset" hidden$="[[ !_enableReset(nodePath, noReset) ]]"></paper-icon-button>
 		</div>
 		<cosmoz-dialog id="dialogTree" class="treeDialog" on-iron-overlay-opened="focusSearch" modal>
 			<h2>[[ dialogText ]]</h2>
-			<cosmoz-treenode-navigator id="treeNavigator" chosen-node="{{ chosenNode }}" tree="[[ tree ]]"
+			<cosmoz-treenode-navigator id="treeNavigator"
+				tree="[[ tree ]]"
+				selected-node="{{ selectedNode }}"
 				on-data-plane-changed="refit"
 				highlighted-node-path="{{ highlightedNodePath }}"
 				search-placeholder="[[ searchPlaceholder ]]"
-				local-search-done-text="[[ localSearchDoneText ]]"
-				reset-text="[[ resetText ]]"
+				search-global-placeholder="[[ searchGlobalPlaceholder ]]"
 				search-min-length="[[ searchMinLength ]]"
-				value="{{ value }}"
-				value-path-parts="{{ valuePathParts }}">
+				node-path="{{ nodePath }}"
+				nodes-on-node-path="{{ nodesOnNodePath }}">
 				<slot></slot>
 			</cosmoz-treenode-navigator>
 			<div class="buttons">

--- a/cosmoz-treenode-button-view.js
+++ b/cosmoz-treenode-button-view.js
@@ -116,6 +116,10 @@
 			*/
 			searchMinLength: {
 				type: Number
+			},
+
+			highlightedNodePath: {
+				type: String
 			}
 		},
 		_enableReset: function (value, noReset) {
@@ -132,22 +136,22 @@
 				return part[this.comparisonProperty];
 			}, this).join(' / ');
 		},
-		openDialogTree: function (event) {
-			this.$.dialogTree.open();			
+		openDialogTree: function () {
+			this.$.dialogTree.open();
 		},
-		focusSearch: function (event) {
+		focusSearch: function () {
 			this.$.treeNavigator.focus();
 		},
-		reset: function (event) {
+		reset: function () {
 			this.value = '';
 		},
-		selectNode: function (event) {
+		selectNode: function () {
 			this.value = this.highlightedNodePath;
 		},
 		refit: function () {
 			this.debounce('refit', function () {
 				this.$.dialogTree.fit();
-			}, 50); // 5 was enough during test
+			}.bind(this), 50); // 5 was enough during test
 		}
 	});
 }());

--- a/cosmoz-treenode-button-view.js
+++ b/cosmoz-treenode-button-view.js
@@ -17,7 +17,7 @@
 				type: Cosmoz.tree
 			},
 			/*
-			 Currently selected node object
+			 * Currently selected node object
 			 */
 			selectedNode: {
 				type: Object,
@@ -67,8 +67,8 @@
 				type: String
 			},
 			/*
-			Settable text for dialog title.
-			*/
+			 * Settable text for dialog title.
+			 */
 			dialogText: {
 				type: String,
 				value: 'Search or navigate to chosen destination'

--- a/cosmoz-treenode-button-view.js
+++ b/cosmoz-treenode-button-view.js
@@ -11,8 +11,7 @@
 
 		properties: {
 			/*
-			Node structure object
-			that component is given
+			 * The main node structure
 			 */
 			tree: {
 				type: Cosmoz.tree
@@ -20,7 +19,7 @@
 			/*
 			 Currently selected node object
 			 */
-			chosenNode: {
+			selectedNode: {
 				type: Object,
 				value: function (){
 					return {};
@@ -28,79 +27,43 @@
 				notify: true
 			},
 			/**
-			 * Prevent reset button
+			 * If true, reset button gets hidden
 			 */
 			noReset: {
 				type: Boolean,
 				value: false
 			},
 			/*
-			Placeholder for search field.
+			 * Placeholder for the search field
 			 */
 			searchPlaceholder: {
 				type: String
 			},
 			/*
-			Placeholder for button text.
+			 * Placeholder for button text
 			 */
 			buttonTextPlaceholder: {
 				type: String,
 				value: 'No selection made'
 			},
 			/*
-			 path value
+			 * The path of the selected node
 			 */
-			value: {
+			nodePath: {
 				type: String,
 				notify: true
 			},
-
-			valuePathParts: {
+			/*
+			 * The nodes on the path of the selected node
+			 */
+			nodesOnNodePath: {
 				type: Array
 			},
 			/*
-			Input value for searches
+			 * Text displayed when local search has finished
+			 * to suggest a search on the entire tree
 			 */
-			inputValue: {
-				type: String
-			},
-			/*
-			 Settable name for property which
-			 houses childobjects.
-			 */
-			childProperty: {
-				type: String,
-				value: 'children'
-			},
-			/*
-			 Settable property name that
-			 searches will be compared too.
-			 */
-			comparisonProperty: {
-				type: String,
-				value: 'name'
-			},
-			/*
-			Chosen separator to denote
-			navigation path.
-			 */
-			separatorSign: {
-				type: String,
-				value: '.'
-			},
-			/*
-			 Settable text given to user
-			 when local search has
-			 been done.
-			 */
-			localSearchDoneText: {
-				type: String
-			},
-			/*
-			Settable text given to user
-			when after an global search.
-			*/
-			resetText: {
+			searchGlobalPlaceholder: {
 				type: String
 			},
 			/*
@@ -111,29 +74,31 @@
 				value: 'Search or navigate to chosen destination'
 			},
 			/*
-			Minimum length before an search
-			starts.
-			*/
+			 * Minimum length before an search
+			 * starts.
+			 */
 			searchMinLength: {
 				type: Number
 			},
-
+			/*
+			 * Path string of highlighted (focused) node
+			 */
 			highlightedNodePath: {
 				type: String
 			}
 		},
-		_enableReset: function (value, noReset) {
+		_enableReset: function (nodePath, noReset) {
 			if (noReset) {
 				return false;
 			}
-			return !!value;
+			return !!nodePath;
 		},
 		_getButtonLabel: function (pathParts, placeholder) {
 			if (!pathParts, pathParts.length < 1) {
 				return placeholder;
 			}
 			return pathParts.map(function (part) {
-				return part[this.comparisonProperty];
+				return part[this.tree.searchProperty];
 			}, this).join(' / ');
 		},
 		openDialogTree: function () {
@@ -143,10 +108,10 @@
 			this.$.treeNavigator.focus();
 		},
 		reset: function () {
-			this.value = '';
+			this.nodePath = '';
 		},
 		selectNode: function () {
-			this.value = this.highlightedNodePath;
+			this.nodePath = this.highlightedNodePath;
 		},
 		refit: function () {
 			this.debounce('refit', function () {

--- a/cosmoz-treenode-navigator.html
+++ b/cosmoz-treenode-navigator.html
@@ -48,12 +48,12 @@ Navigator through object with treelike datastructure.
 			<h3 class="layout horizontal center wrap">
 				<a href="#" data-path="" on-click="openNode"><iron-icon icon="home"></iron-icon></a>
 				<template is="dom-repeat" items="[[ _openNodeLevelPathParts ]]" as="node">
-					<span class="slash">/</span><a href="#" data-path$="[[ node.path ]]" on-click="openNode">[[ getNodeName(node) ]]</a>
+					<span class="slash">/</span><a href="#" data-path$="[[ node.path ]]" on-click="openNode">[[ _getNodeName(node) ]]</a>
 				</template>
 			</h3>
 			<paper-input tabindex="0" id="searchInput" class="flex" label="[[ searchPlaceholder ]]" title$="[[ searchPlaceholder ]]"
 				id="searchInput" value="{{ inputValue }}">
-				<a suffix hidden$="[[ !_searching ]]" href="#" on-tap="clearSearch"><iron-icon icon="clear"></iron-icon></a>
+				<a suffix hidden$="[[ !_searching ]]" href="#" on-tap="_clearSearch"><iron-icon icon="clear"></iron-icon></a>
 			</paper-input>
 		</div>
 		<iron-list items="[[dataPlane]]" as="node">
@@ -67,7 +67,7 @@ Navigator through object with treelike datastructure.
 				</div>
 			</template>
 		</iron-list>
-		<paper-button hidden$="[[ !showGlobalSearch(_searching, _openNodeLevelPath) ]]" on-click="tryGlobalSearch">[[ localSearchDoneText ]]</paper-button>
+		<paper-button hidden$="[[ !_showGlobalSearchBtn(_searching, _openNodeLevelPath) ]]" on-click="tryGlobalSearch">[[ localSearchDoneText ]]</paper-button>
 	</template>
 	<script type="text/javascript" src="cosmoz-treenode-navigator.js"></script>
 </dom-module>

--- a/cosmoz-treenode-navigator.html
+++ b/cosmoz-treenode-navigator.html
@@ -47,19 +47,19 @@ Navigator through object with treelike datastructure.
 		<div id="header">
 			<h3 class="layout horizontal center wrap">
 				<a href="#" data-path="" on-click="openNode"><iron-icon icon="home"></iron-icon></a>
-				<template is="dom-repeat" items="[[ _openNodeLevelPathParts ]]" as="node">
+				<template is="dom-repeat" items="[[ _nodesOnOpenNodePath ]]" as="node">
 					<span class="slash">/</span><a href="#" data-path$="[[ node.path ]]" on-click="openNode">[[ _getNodeName(node) ]]</a>
 				</template>
 			</h3>
 			<paper-input tabindex="0" id="searchInput" class="flex" label="[[ searchPlaceholder ]]" title$="[[ searchPlaceholder ]]"
-				id="searchInput" value="{{ inputValue }}">
-				<a suffix hidden$="[[ !_searching ]]" href="#" on-tap="_clearSearch"><iron-icon icon="clear"></iron-icon></a>
+				id="searchInput" value="{{ searchValue }}">
+				<a suffix hidden$="[[ !_search ]]" href="#" on-tap="_clearSearch"><iron-icon icon="clear"></iron-icon></a>
 			</paper-input>
 		</div>
 		<iron-list items="[[dataPlane]]" as="node">
 			<template>
 				<div>
-					<div class="section" hidden$="[[ !_renderSection(_searching, index, dataPlane, node) ]]">[[ node.sectionName ]]</div>
+					<div class="section" hidden$="[[ !_renderSection(_search, index, dataPlane, node) ]]">[[ node.sectionName ]]</div>
 					<paper-item on-tap="_nodeSelected" class="nodeItem">
 						<span class="flex">[[ node.name ]]</span>
 						<iron-icon hidden$="[[ !hasChildren(node) ]]" data-path$="[[ node.path ]]" icon="icons:arrow-forward" on-click="openNode"></iron-icon>
@@ -67,7 +67,7 @@ Navigator through object with treelike datastructure.
 				</div>
 			</template>
 		</iron-list>
-		<paper-button hidden$="[[ !_showGlobalSearchBtn(_searching, _openNodeLevelPath) ]]" on-click="tryGlobalSearch">[[ localSearchDoneText ]]</paper-button>
+		<paper-button hidden$="[[ !_showGlobalSearchBtn(_search, _openNodePath) ]]" on-click="tryGlobalSearch">[[ searchGlobalPlaceholder ]]</paper-button>
 	</template>
 	<script type="text/javascript" src="cosmoz-treenode-navigator.js"></script>
 </dom-module>

--- a/cosmoz-treenode-navigator.js
+++ b/cosmoz-treenode-navigator.js
@@ -122,18 +122,24 @@
 		},
 		/**
 		 * Focusses the search input.
+		 * @return {undefined}
 		 */
 		focus: function () {
 			this.$.searchInput.inputElement.focus();
 		},
 		/**
 		 * Sets highlightedNodePath if a user selects a node.
+		 * @param {Event} e - Event
+		 * @return {undefined}
 		 */
 		_nodeSelected: function (e) {
 			this.highlightedNodePath = e.model.node.path;
 		},
 		/**
 		 * Returns a node array with the children of the given path.
+		 * @param {String} pathLocator - The separated address parts of a node
+		 * @param {Tree} tree - The main tree
+		 * @return {Array} - Nodes
 		 */
 		_renderLevel: function (pathLocator, tree) {
 			if (!tree) {
@@ -147,8 +153,10 @@
 		/**
 		 * Normalizes and returns an Array of nodes
 		 * with the properties name, path, sectionName, children
+		 * @param {Array} nodes - The input nodes
+		 * @return {Array} - The normalized nodes
 		 */
-		_normalizeNodes: function (nodes) { 
+		_normalizeNodes: function (nodes) {
 			return nodes.map(function (node) {
 				var path = node.pathLocator || node.path;
 				return {
@@ -162,6 +170,9 @@
 		/**
 		 * Returns a node based on a given path locator.
 		 * If pathLocator is empty or not defined, null gets returned.
+		 * @param {String} pathLocator - The separated address parts of a node
+		 * @param {Tree} tree - The main tree
+		 * @return {Object} - The found node
 		 */
 		_getNode: function (pathLocator, tree) {
 			if (!pathLocator || !tree) {
@@ -169,13 +180,23 @@
 			}
 			return this.tree.getNodeByPathLocator(pathLocator);
 		},
+		/**
+		 * Returns the nodes on a path specified by a given path locator
+		 * @param {String} pathLocator - The separated address parts of a node
+		 * @param {Tree} tree - The main tree
+		 * @return {Array} - The found nodes or empty array
+		 */
 		_getTreePathParts: function (pathLocator, tree) {
 			if (!tree || !pathLocator) {
 				return [];
-			};
+			}
 			return this._normalizeNodes(tree.getPathNodes(pathLocator));
 		},
-		clearSearch: function (event) {
+		/**
+		 * Clears the search input element
+		 * @return {undefined}
+		 */
+		clearSearch: function () {
 			event.preventDefault();
 			event.stopPropagation();
 			this.inputValue = '';

--- a/demo/index.html
+++ b/demo/index.html
@@ -28,7 +28,7 @@
 			  <demo-snippet>
 				<template is="dom-bind" id="demo">
 					<iron-ajax url="data/multiRootTree.json" handle-as="json" last-response="{{ treeData }}" auto></iron-ajax>
-					<cosmoz-treenode-button-view id="navigator" value="{{ path }}" chosen-node="{{ nodeChosen1 }}" tree="[[ getTree(treeData) ]]"></cosmoz-treenode-button-view>
+					<cosmoz-treenode-button-view id="navigator" node-path="{{ path }}" selected-node="{{ nodeChosen1 }}" tree="[[ getTree(treeData) ]]"></cosmoz-treenode-button-view>
 				</template>
 			  </demo-snippet>
 		 </div>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="import" href="../iron-component-page/iron-component-page.html">
   </head>
   <body>
-    <iron-component-page src="cosmoz-treenode-navigator.html"></iron-component-page>
+	<iron-component-page src="cosmoz-treenode-navigator.html"></iron-component-page>
+	<iron-component-page src="cosmoz-treenode-button-view.html"></iron-component-page>
   </body>
 </html>

--- a/test/cosmoz-treenode-navigator_test.html
+++ b/test/cosmoz-treenode-navigator_test.html
@@ -27,37 +27,37 @@
       </template>
     </test-fixture>
 
-    <script>
-      (function () {
-		    'use strict';
-        suite('cosmoz-treenode-navigator', function() {
-          var basicFixture,
-              basicTree,
-              navigator;
+	<script>
+		(function () {
+			'use strict';
+			suite('cosmoz-treenode-navigator', function () {
+				var basicFixture,
+					basicTree,
+					navigator;
 
-          suiteSetup(function (done) {
-            var ajax;
-            basicFixture = fixture('basic');
-            ajax = basicFixture.find(function (n) { 
-              return n.is === 'iron-ajax';
-            });
-            navigator = basicFixture.find(function (n) { 
-                return n.is === 'cosmoz-treenode-navigator';
-            });
+				suiteSetup(function (done) {
+					var ajax;
+					basicFixture = fixture('basic');
+					ajax = basicFixture.find(function (n) {
+						return n.is === 'iron-ajax';
+					});
+					navigator = basicFixture.find(function (n) {
+						return n.is === 'cosmoz-treenode-navigator';
+					});
 
-            ajax.addEventListener('response', function () {
-              basicTree = new Cosmoz.DefaultTree(ajax.lastResponse);
-              navigator.tree = basicTree;
-              done();
-            });
-          });
+					ajax.addEventListener('response', function () {
+						basicTree = new Cosmoz.DefaultTree(ajax.lastResponse);
+						navigator.tree = basicTree;
+						done();
+					});
+				});
 
-          test('instantiating the element', function() {
-            assert.equal(navigator.is, 'cosmoz-treenode-navigator');
-          });
+				test('instantiating the element', function () {
+					assert.equal(navigator.is, 'cosmoz-treenode-navigator');
+				});
 
-        });
-      }());
+			});
+		}());
     </script>
   </body>
 </html>


### PR DESCRIPTION
Some properties have been removed as they were not used.
Some private properties were renamed.

API changes:
Sorry for the api changes but I struggled a bit writing the docs as some names were misleanding (at least for me). Think the sooner we do it the less hassle we have.

Public properties changed:

**Navigator**
- inputValue => searchValue
- chosenNode => selectedNode
- value => nodePath
- valuePathParts => nodesOnNodePath
- localSearchDoneText => searchGlobalPlaceholder

**Button View**
- chosenNode => selectedNode
- value => nodePath
- valuePathParts => nodesOnNodePath
- localSearchDoneText => searchGlobalPlaceholder

Please let me know.
and I'll:
- close https://github.com/Neovici/cosmoz-treenode-navigator/pull/11
- rebase https://github.com/Neovici/cosmoz-treenode-navigator/pull/10