### PR TITLE
Handle non array in _normalizeNodes

### DIFF
--- a/cosmoz-treenode-navigator.js
+++ b/cosmoz-treenode-navigator.js
@@ -189,6 +189,9 @@
 		 * @return {Array} - The normalized nodes
 		 */
 		_normalizeNodes: function (nodes) {
+			if (!Array.isArray(nodes)){
+				return [];
+			}
 			return nodes.map(function (node) {
 				var path = node.pathLocator || node.path;
 				return {


### PR DESCRIPTION
Handle non array in `_normalizeNodes`. 
nodes can be null when `tree.getPathNodes(pathLocator)` returns nothing.