### PR TITLE
Prevent iron-list from handling selection tap event on itself

### DIFF
--- a/cosmoz-treenode-navigator.html
+++ b/cosmoz-treenode-navigator.html
@@ -91,7 +91,7 @@ Navigator through object with treelike datastructure.
 				<paper-icon-button icon="clear" suffix hidden$="[[ !_search ]]" on-tap="_clearSearch"></paper-icon-button>
 			</paper-input>
 		</div>
-		<iron-list items="[[dataPlane]]" as="node" selected-item="{{highlightedNode}}" selection-enabled>
+		<iron-list items="[[dataPlane]]" as="node" selected-item="{{highlightedNode}}" selection-enabled on-tap="_onListTap">
 			<template>
 				<div tabindex$="[[tabIndex]]">
 					<div

--- a/cosmoz-treenode-navigator.js
+++ b/cosmoz-treenode-navigator.js
@@ -361,6 +361,15 @@
 		 */
 		_computeRowClass: function (classes, selected) {
 			return selected ? classes + ' selected' : classes;
+		},
+
+		_onListTap(e){
+			// Prevent iron-list from calling getModelForElement on itself otherwise it triggers a infinite loop
+			// because `cosmoz-dialog` weirdly sets dataHost.
+			if (e.target && e.target.is === 'iron-list'){
+				console.warn('stopImmediatePropagation for tap directly on iron-list');
+				e.stopImmediatePropagation();
+			}
 		}
 	});
 }());


### PR DESCRIPTION
Prevent iron-list from handling selection tap event on itself.
`iron-list` handles tap event for changing selection on itself and calls `modelForElement`.
This loops upward and when it gets to `cosmoz-dialog` a infinite loop is triggered because dataHost is itself.