### PR TITLE
Multi-selection feature

### DIFF
--- a/cosmoz-treenode-button-view.html
+++ b/cosmoz-treenode-button-view.html
@@ -31,6 +31,40 @@ Navigator through object with treelike datastructure.
 				@apply --cosmoz-treenode-button-view-dialog-container;
 			}
 
+			#chips {
+				@apply --layout-horizontal;
+				@apply --layout-end;
+				@apply --layout-wrap;
+				max-width: 90%;
+			}
+			.chip {
+				border-radius: 500px;
+				background-color: #e0e0e0;
+				margin: 1px 4px 1px 0;
+				white-space: nowrap;
+				overflow: hidden;
+				@apply --layout-horizontal;
+				@apply --layout-center;
+			}
+			.chip > span {
+				color: #424242;
+				margin-left: 10px;
+				font-size: 13px;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+			.chip iron-icon {
+				margin: 2px 4px;
+				color: #cdcdcd;
+				background-color: #a6a6a6;
+				border-radius: 500px;
+				cursor: pointer;
+				min-width: 16px;
+				width: 16px;
+				min-height: 16px;
+				height: 16px;
+			}
+
 			#dialogTree {
 				min-width: 250px !important;
 				width: 450px;
@@ -42,12 +76,19 @@ Navigator through object with treelike datastructure.
 			}
 
 		</style>
+
 		<div class="horizontal layout actions">
 			<paper-button class="flex" raised on-tap="openDialogTree">
 				<div class="pathToNode">[[ _getButtonLabel(nodesOnNodePath, buttonTextPlaceholder) ]]</div>
 			</paper-button>
+			<div id="chips" class="row">
+				<template is="dom-repeat" items="[[ selectedNodes ]]">
+					<div class="chip"><span>[[ _getChipText(item,tree) ]]</span><iron-icon icon="clear" on-click="_clearItemSelection"></iron-icon></div>
+				</template>
+			</div>
 			<paper-icon-button icon="clear" on-tap="reset" hidden$="[[ !_enableReset(nodePath, noReset) ]]"></paper-icon-button>
 		</div>
+
 		<cosmoz-dialog id="dialogTree" class="treeDialog" on-iron-overlay-opened="focusSearch" modal prerender>
 			<template>
 				<h2>[[ dialogText ]]</h2>
@@ -69,6 +110,7 @@ Navigator through object with treelike datastructure.
 				</div>
 			</template>
 		</cosmoz-dialog>
+
 	</template>
 	<script type="text/javascript" src="cosmoz-treenode-button-view.js"></script>
 </dom-module>

--- a/cosmoz-treenode-button-view.html
+++ b/cosmoz-treenode-button-view.html
@@ -36,6 +36,7 @@ Navigator through object with treelike datastructure.
 				@apply --layout-end;
 				@apply --layout-wrap;
 				max-width: 90%;
+				padding: 20px;
 			}
 			.chip {
 				border-radius: 500px;
@@ -77,16 +78,20 @@ Navigator through object with treelike datastructure.
 
 		</style>
 
-		<div class="horizontal layout actions">
-			<paper-button class="flex" raised on-tap="openDialogTree">
-				<div class="pathToNode">[[ _getButtonLabel(nodesOnNodePath, buttonTextPlaceholder) ]]</div>
-			</paper-button>
-			<div id="chips" class="row">
-				<template is="dom-repeat" items="[[ selectedNodes ]]">
-					<div class="chip"><span>[[ _getChipText(item,tree) ]]</span><iron-icon icon="clear" on-click="_clearItemSelection"></iron-icon></div>
-				</template>
+		<div class="vertical layout actions">
+			<div class="horizontal layout actions">
+				<paper-button class="flex" raised on-tap="openDialogTree">
+					<div class="pathToNode">[[ _getButtonLabel(nodesOnNodePath, buttonTextPlaceholder) ]]</div>
+				</paper-button>
+				<paper-icon-button icon="clear" on-tap="reset" hidden$="[[ !_enableReset(nodePath, noReset) ]]"></paper-icon-button>
 			</div>
-			<paper-icon-button icon="clear" on-tap="reset" hidden$="[[ !_enableReset(nodePath, noReset) ]]"></paper-icon-button>
+			<template is="dom-if" if="[[ _showSelectedNodes(multiSelection, selectedNodes.length) ]]">
+				<div id="chips" class="row">
+					<template is="dom-repeat" items="[[ selectedNodes ]]">
+						<div class="chip"><span>[[ _getChipText(item,tree) ]]</span><iron-icon icon="clear" on-click="_clearItemSelection"></iron-icon></div>
+					</template>
+				</div>
+			</template>
 		</div>
 
 		<cosmoz-dialog id="dialogTree" class="treeDialog" on-iron-overlay-opened="focusSearch" modal prerender>

--- a/cosmoz-treenode-button-view.js
+++ b/cosmoz-treenode-button-view.js
@@ -98,6 +98,11 @@
 				type: String
 			}
 		},
+		/**
+		 * Event handler for node chip removal button, removes a node chip.
+		 * @param {object} event Polymer event object.
+		 * @returns {void}
+		 */
 		_clearItemSelection(event) {
 			let item = event.model.item,
 				selectedIndex = this.selectedNodes.indexOf(item);
@@ -109,45 +114,95 @@
 			event.preventDefault();
 			event.stopPropagation();
 		},
+		/**
+		 * Get a text label for the node selection button.
+		 * @param {boolean} multiSelection Multi selection setting.
+		 * @returns {string} Text label.
+		 */
 		getButtonTextPlaceholder(multiSelection) {
-			return multiSelection ? 'Select a node' : 'No selection made';
+			return multiSelection ? this._('Select a node') : this._('No selection made');
 		},
+		/**
+		 * Whether the reset button should be enabled or not.
+		 * @param {string} nodePath Node path to check.
+		 * @param {boolean} noReset Bypass to force disabled.
+		 * @returns {boolean} Whether the button should be enabled or not.
+		 */
 		_enableReset(nodePath, noReset) {
 			if (noReset) {
 				return false;
 			}
 			return !!nodePath;
 		},
+		/**
+		 * Get a button label based on path parts or a placeholder.
+		 * @param {array} pathParts Nodes on the node path.
+		 * @param {string} placeholder Replacement placeholder if no nodes are available.
+		 * @returns {string} Button label.
+		 */
 		_getButtonLabel(pathParts, placeholder) {
 			if (!Array.isArray(pathParts) || pathParts.length === 0) {
 				return placeholder;
 			}
 			return pathParts.filter(n => n).map(part => part[this.tree.searchProperty]).join(' / ');
 		},
+		/**
+		 * Get text from a node to set on a node chip.
+		 * @param {object} node Node to get text from.
+		 * @returns {string} Chip text.
+		 */
 		_getChipText(node) {
 			return node.name;
 		},
+		/**
+		 * Open the treenode navigator dialog.
+		 * @returns {void}
+		 */
 		openDialogTree() {
 			this.$.dialogTree.open();
 		},
+		/**
+		 * Focus on the treenode navigator in the treenode navigator dialog.
+		 * @returns {void}
+		 */
 		focusSearch() {
 			this.$.dialogTree.paperDialog.querySelector('#treeNavigator').focus();
 		},
+		/**
+		 * Reset the component to make it ready for reuse
+		 * @returns {void}
+		 */
 		reset() {
 			this.nodePath = '';
 			this.selectedNodes = [];
 		},
+		/**
+		 * Select the node in the treenode navigator.
+		 * @returns {void}
+		 */
 		selectNode() {
+			// nodePath selects the node, without it no selectedNode
+			this.nodePath = this.highlightedNodePath;
 			if (this.multiSelection) {
-				if (!this.selectedNodes.some(nodePath => nodePath === this.highlightedNodePath)) {
-					this.push('selectedNodes', this.tree.getNodeByPathLocator(this.highlightedNodePath));
+				if (!this.selectedNodes.some(node => node.pathLocator === this.highlightedNodePath)) {
+					this.push('selectedNodes', this.selectedNode);
 				}
 				this.nodePath = '';
 				this.selectedNode = {};
-			} else {
-				this.nodePath = this.highlightedNodePath;
 			}
 		},
+		/**
+		 * Determine if selected nodes container should be visible or not.
+		 * @param {boolean} multiSelection Multi selection setting.
+		 * @param {number} selectedNodesLength Selected nodes quantity.
+		 * @returns {boolean} Whether the selected nodes container should be visible or not.
+		 */
+		_showSelectedNodes: (multiSelection, selectedNodesLength) => multiSelection && selectedNodesLength > 0,
+		/**
+		 * Callback event handler to refit the treenode navigator dialog when
+		 * data plane has changed.
+		 * @returns {void}
+		 */
 		refit() {
 			this.debounce('refit', function () {
 				this.$.dialogTree.fit();


### PR DESCRIPTION
This pull request enables multi-selection in the component, by adding removeable chips for each selected node as requested in Redmine #19510.

I need some help on improving this, especially:
- The design, not sure how to get the chips on a new line.
- What to return in `selectedNodes`, currently I get the node from the tree, not sure if it should be done that way. Tried using `selectedNode` data but that was always `null`, maybe because the dialog closes.