### PR TITLE
cosmoz-treenode-navigator: null checks added. NOREF

### DIFF
--- a/cosmoz-treenode-navigator.js
+++ b/cosmoz-treenode-navigator.js
@@ -341,7 +341,7 @@
 		 * @return {Boolean} - If the path should be visible
 		 */
 		_renderSection(searching, index, dataPlane, node) {
-			if (searching == null || !searching || index == null || dataPlane == null || index >= dataPlane.length || node == null || node.sectionName == null) {
+			if (!searching || index == null || dataPlane == null || index >= dataPlane.length || node == null || node.sectionName == null) {
 				return false;
 			}
 			if (index === 0) {

--- a/cosmoz-treenode-navigator.js
+++ b/cosmoz-treenode-navigator.js
@@ -341,7 +341,7 @@
 		 * @return {Boolean} - If the path should be visible
 		 */
 		_renderSection(searching, index, dataPlane, node) {
-			if (!searching || index >= dataPlane.length || !node || !node.sectionName) {
+			if (searching == null || !searching || index == null || dataPlane == null || index >= dataPlane.length || node == null || node.sectionName == null) {
 				return false;
 			}
 			if (index === 0) {


### PR DESCRIPTION
* Adds null check
* Error found in LogEntries - `Uncaught TypeError: Cannot read property \'length\' of undefined`