### PR TITLE
20827 - Setting paper-font-common-base to override font-family

### DIFF
--- a/cosmoz-treenode-navigator.html
+++ b/cosmoz-treenode-navigator.html
@@ -54,6 +54,7 @@ Navigator through object with treelike datastructure.
 
 				.node-item {
 					font-family: 'Roboto', 'Noto', sans-serif;
+					@apply --paper-font-common-base;
 					-webkit-font-smoothing: antialiased;
 					padding: 6px 12px;
 					font-size: 16px;


### PR DESCRIPTION
This overrides the font-family with paper-font-common-base, which seems to be the common practice to be able to control the font from the outside.

Testing: Connect to cosmoz-frontend, change the font-family in `--paper-font-common-base` for the theme.

Issue is Redmine 20827.