### PR TITLE
Replacing translation behavior with mixin, upgrading cosmoz-i18next component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
 		"paper-button": "PolymerElements/paper-button#^2.0.0",
 		"iron-flex-layout": "PolymerElements/iron-flex-layout#^2.0.0",
 		"iron-list": "PolymerElements/iron-list#^2.0.0",
-		"cosmoz-i18next": "Neovici/cosmoz-i18next#^2.0.0",
+		"cosmoz-i18next": "Neovici/cosmoz-i18next#^2.0.1",
 		"cosmoz-dialog": "Neovici/cosmoz-dialog#^2.0.1",
 		"cosmoz-tree": "Neovici/cosmoz-tree#^2.0.0"
 	},

--- a/cosmoz-treenode-button-view.js
+++ b/cosmoz-treenode-button-view.js
@@ -1,7 +1,8 @@
+/*global Cosmoz,Polymer*/
 (() => {
 	'use strict';
 
-	class CosmozTreenodeButtonView extends Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element) {
+	class CosmozTreenodeButtonView extends Cosmoz.Mixins.translatable(Polymer.Element) {
 		static get is() {
 			return 'cosmoz-treenode-button-view';
 		}

--- a/cosmoz-treenode-navigator.js
+++ b/cosmoz-treenode-navigator.js
@@ -1,7 +1,8 @@
+/*global Cosmoz,Polymer*/
 (() => {
 	'use strict';
 
-	class CosmozTreenodeNavigator extends Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element) {
+	class CosmozTreenodeNavigator extends Cosmoz.Mixins.translatable(Polymer.Element) {
 		static get is() {
 			return 'cosmoz-treenode-navigator';
 		}


### PR DESCRIPTION
Replacing translation behavior with mixin, upgrading cosmoz-i18next component.

Had to upgrade the component because the mixin is in `cosmoz-i18next^2.0.1`.

Testing, `yarn install; yarn start`.

Build errors are Chrome 74-76 errors.

Issue is Neovici/cosmoz-frontend#815.