### PR TITLE
feat(select): close dialog manually

### DIFF
--- a/cosmoz-treenode-button-view.js
+++ b/cosmoz-treenode-button-view.js
@@ -155,7 +155,6 @@ class CosmozTreenodeButtonView extends translatable(PolymerElement) {
 					<div class="buttons">
 						<paper-button
 							disabled="[[!highlightedNodePath]]"
-							dialog-confirm
 							autofocus
 							on-click="selectNode"
 							>[[ _('Select', t) ]]</paper-button
@@ -404,6 +403,7 @@ class CosmozTreenodeButtonView extends translatable(PolymerElement) {
 			this.nodePath = '';
 			this.selectedNode = {};
 		}
+		this.$.dialogTree.close();
 	}
 	/**
 	 * Selects node and closes the dialog
@@ -411,7 +411,6 @@ class CosmozTreenodeButtonView extends translatable(PolymerElement) {
 	 */
 	_selectNodeAndCloseDialog() {
 		this.selectNode();
-		this.$.dialogTree.close();
 	}
 	/**
 	 * Determine if selected nodes container should be visible or not.


### PR DESCRIPTION
[AB#8428](https://dev.azure.com/neovici/Cosmoz3/_workitems/edit/8424)

Sometimes on iOS devices the node wasn't selected after clicking on the `Select` button.
I did some investigation and found out that sometimes the dialog has been closed before the `selectNode` method was invoked. 

After we merge and release this PR we have to update dependencies in the Cosmoz App.