### PR TITLE
fix(dependencies): newest input dependencies are needed in all the repos using them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@neovici/cfg": "^1.33.0",
 				"@neovici/cosmoz-dialog": "^3.0.0",
 				"@neovici/cosmoz-i18next": "^3.2.0",
-				"@neovici/cosmoz-input": "^4.0.0",
+				"@neovici/cosmoz-input": "^5.0.0",
 				"@neovici/cosmoz-tree": "^3.0.0",
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",
@@ -1081,9 +1081,9 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-input": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-4.0.0.tgz",
-			"integrity": "sha512-c0ZkxOAOm3wPT9LEUAitNc7+a/meW3yhxGZrqDaLmodqcw7lIXRNZpiMN4E+ekdxHuq3RViM1TrWTUwqhiCxyA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-5.0.0.tgz",
+			"integrity": "sha512-/VgXn27TJ/dPJd3aUoyoso6NIMr4Q6duWR4chxPTc5m70g9fHLB1fTO7/Ph9rUYejYRNUZZ4ie+pNfTl0Cbneg==",
 			"dependencies": {
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"@neovici/cfg": "^1.33.0",
 		"@neovici/cosmoz-dialog": "^3.0.0",
 		"@neovici/cosmoz-i18next": "^3.2.0",
-		"@neovici/cosmoz-input": "^4.0.0",
+		"@neovici/cosmoz-input": "^5.0.0",
 		"@neovici/cosmoz-tree": "^3.0.0",
 		"@neovici/cosmoz-utils": "^6.0.0",
 		"@pionjs/pion": "^2.0.0",


### PR DESCRIPTION
About Feature [AB#11519](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/11519) - latest cosmoz-input release (v5.0.0) needs to be installed in all the components using it.