### PR TITLE
fix: font styles didn't follow convert pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # [7.1.0](https://github.com/neovici/cosmoz-treenode-navigator/compare/v7.0.2...v7.1.0) (2025-04-10)
 
-
 ### Features
 
-* debounce search and optimize state ([#149](https://github.com/neovici/cosmoz-treenode-navigator/issues/149)) ([1774f3e](https://github.com/neovici/cosmoz-treenode-navigator/commit/1774f3e62585ef0ee50546259359796462b4bfec))
+- debounce search and optimize state ([#149](https://github.com/neovici/cosmoz-treenode-navigator/issues/149)) ([1774f3e](https://github.com/neovici/cosmoz-treenode-navigator/commit/1774f3e62585ef0ee50546259359796462b4bfec))
 
 ## [7.0.2](https://github.com/neovici/cosmoz-treenode-navigator/compare/v7.0.1...v7.0.2) (2025-03-31)
 

--- a/src/cosmoz-treenode-button-view.styles.ts
+++ b/src/cosmoz-treenode-button-view.styles.ts
@@ -59,7 +59,9 @@ export default css`
 		margin: 14px 14px 12px 14px;
 
 		color: var(--cosmoz-treenode-actions-button-text-color, #101010);
-		font-size: 14px;
+		font: inherit;
+		font-size: inherit;
+		line-height: inherit;
 
 		background-color: var(
 			--cosmoz-treenode-actions-button-background-color,


### PR DESCRIPTION
When updating this package (after [conversion to Pion and TS](https://github.com/Neovici/cosmoz-treenode-navigator/pull/146) was made), I noticed font styles wasn't the same as before. This PR fixes that.