### PR TITLE
feat: expand i18next range to >=23.0.0 <27.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@neovici/cosmoz-tree": "^3.7.3",
 				"@neovici/cosmoz-utils": "^6.8.1",
 				"@pionjs/pion": "^2.12.0",
-				"i18next": "^23.12.2",
+				"i18next": ">=23.0.0 <27.0.0",
 				"lit-html": "^2.0.0 || ^3.0.0"
 			},
 			"devDependencies": {
@@ -194,7 +194,9 @@
 			"version": "7.28.6",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
 			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -8781,26 +8783,31 @@
 			}
 		},
 		"node_modules/i18next": {
-			"version": "23.16.8",
-			"resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
-			"integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+			"version": "26.0.10",
+			"resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.10.tgz",
+			"integrity": "sha512-k3yGPAlWR2RdMYoVXJoDZDT87qeHIWKH7gVksdZMpRty7QX/D9QZeYGvN08KGbKHke9wn01eYT+EEsrqX/YTlw==",
 			"funding": [
 				{
 					"type": "individual",
-					"url": "https://locize.com"
-				},
-				{
-					"type": "individual",
-					"url": "https://locize.com/i18next.html"
+					"url": "https://www.locize.com/i18next"
 				},
 				{
 					"type": "individual",
 					"url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.locize.com"
 				}
 			],
 			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.23.2"
+			"peerDependencies": {
+				"typescript": "^5 || ^6"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -17371,7 +17378,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
 		"@neovici/cosmoz-tree": "^3.7.3",
 		"@neovici/cosmoz-utils": "^6.8.1",
 		"@pionjs/pion": "^2.12.0",
-		"i18next": "^23.12.2",
+		"i18next": ">=23.0.0 <27.0.0",
 		"lit-html": "^2.0.0 || ^3.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary
- Expand i18next semver range from ^23.12.2 to >=23.0.0 <27.0.0
- This is a non-breaking range expansion: v23.x is still accepted, while also allowing v25.x and v26.x
- No source code changes — this package gets i18next transitively via cosmoz-i18next
- Part of FE-609 (fix duplicate singleton packages)

Resolves FE-616