### PR TITLE
feat: add variant attribute to cosmoz-treenode-button-view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"@commitlint/cli": "^20.0.0",
 				"@commitlint/config-conventional": "^20.0.0",
 				"@neovici/cfg": "^2.8.0",
-				"@playwright/test": "^1.58.1",
+				"@playwright/test": "^1.60.0",
 				"@semantic-release/changelog": "^6.0.0",
 				"@semantic-release/git": "^10.0.0",
 				"@storybook/addon-docs": "^10.0.0",
@@ -1749,13 +1749,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+			"integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.58.2"
+				"playwright": "1.61.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -14531,13 +14531,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.58.2"
+				"playwright-core": "1.61.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -14550,9 +14550,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
 		"@commitlint/cli": "^20.0.0",
 		"@commitlint/config-conventional": "^20.0.0",
 		"@neovici/cfg": "^2.8.0",
-		"@playwright/test": "^1.58.1",
+		"@playwright/test": "^1.60.0",
 		"@semantic-release/changelog": "^6.0.0",
 		"@semantic-release/git": "^10.0.0",
 		"@storybook/addon-docs": "^10.0.0",

--- a/src/cosmoz-treenode-button-view.ts
+++ b/src/cosmoz-treenode-button-view.ts
@@ -21,14 +21,22 @@ import './cosmoz-treenode-navigator';
 import { useKeyDown } from './hooks/useKeyDown';
 import { getTreePathParts } from './util/helpers';
 
+type ButtonVariant =
+	| 'primary'
+	| 'secondary'
+	| 'tertiary'
+	| 'destructive'
+	| 'link';
+
 type ButtonViewProps = {
 	tree: Tree;
 	showReset?: boolean;
 	searchMinLength?: number;
 	searchDebounceTimeout: number;
+	variant?: ButtonVariant;
 };
 
-type ObservedAttributes = 'show-reset' | 'search-min-length';
+type ObservedAttributes = 'show-reset' | 'search-min-length' | 'variant';
 
 type ButtonViewDialog = HTMLDialogElement & {
 	fit: () => void;
@@ -56,6 +64,7 @@ const CosmozNodeButtonView = ({
 	showReset = false,
 	searchMinLength = 3,
 	searchDebounceTimeout = 500,
+	variant = 'secondary',
 }: ButtonViewProps) => {
 	const dialogRef = useRef<ButtonViewDialog | null>(null);
 	const tooltipTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
@@ -180,7 +189,7 @@ const CosmozNodeButtonView = ({
 				.disabled=${tooltipDisabled}
 			>
 				<cosmoz-button
-					variant="secondary"
+					variant=${variant}
 					full-width
 					data-testid="open-button"
 					@click=${onOpen}
@@ -259,6 +268,7 @@ const CosmozNodeButtonView = ({
 CosmozNodeButtonView.observedAttributes = [
 	'show-reset',
 	'search-min-length',
+	'variant',
 ] as readonly ObservedAttributes[];
 
 customElements.define(


### PR DESCRIPTION
Add a `variant` attribute (observed, defaults to `'secondary'`) that controls the open button's variant. This allows consumers to change the button variant (e.g. to `'tertiary'`) without modifying the component.

The variant only affects the open button in the `<nav>` — the reset button stays `tertiary` and dialog buttons (Select/Cancel) keep their fixed variants.

Usage:
```html
<cosmoz-treenode-button-view variant="tertiary" ...></cosmoz-treenode-button-view>
```