### PR TITLE
chore: bump playwright to 1.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 			"devDependencies": {
 				"@changesets/cli": "^2.31.0",
 				"@neovici/cfg": "^2.8.0",
-				"@playwright/test": "^1.60.0",
+				"@playwright/test": "1.60.0",
 				"@storybook/addon-docs": "^10.0.0",
 				"@storybook/addon-vitest": "^10.2.4",
 				"@storybook/web-components-vite": "^10.2.4",
@@ -2003,13 +2003,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
-			"integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.61.0"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -10581,13 +10581,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.61.0"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -10600,9 +10600,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.61.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 	"devDependencies": {
 		"@changesets/cli": "^2.31.0",
 		"@neovici/cfg": "^2.8.0",
-		"@playwright/test": "^1.60.0",
+		"@playwright/test": "1.60.0",
 		"@storybook/addon-docs": "^10.0.0",
 		"@storybook/addon-vitest": "^10.2.4",
 		"@storybook/web-components-vite": "^10.2.4",


### PR DESCRIPTION
Pin `@playwright/test` to exact version `1.60.0` to avoid browser version mismatches when running `@vitest/browser-playwright`.\n\nRelates to FE-879